### PR TITLE
Redis接続確認用のPing APIを実装

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   rspec:
@@ -89,3 +91,10 @@ jobs:
           eval $(ssh-agent)
           ssh-add ~/.ssh/Achieve-docker-ec2
           ssh -o StrictHostKeyChecking=no -A webapp@${{ secrets.TARGET_HOSTNAME }} "cd Achieve && git pull origin master && docker-compose restart"
+
+  ping:
+    name: Weekly Redis Ping
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send ping request to Redis endpoint
+        run: curl -s https://backend-goals-achieve.onrender.com/ping

--- a/achieve_rails/.env
+++ b/achieve_rails/.env
@@ -1,2 +1,0 @@
-VUE_APP_API_BASE_URL=http://localhost:3000
-VUE_APP_CABLE_URL=ws://localhost:3000

--- a/achieve_rails/.gitignore
+++ b/achieve_rails/.gitignore
@@ -6,7 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
-.env
+/.env
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/achieve_rails/app/controllers/ping_controller.rb
+++ b/achieve_rails/app/controllers/ping_controller.rb
@@ -1,0 +1,8 @@
+class PingController < ApplicationController
+  def index
+    result = Rails.application.config.redis.ping
+    render json: { status: 'success', message: result }, status: :ok
+  rescue StandardError => e
+    render json: { status: 'error', message: e.message }, status: :internal_server_error
+  end
+end

--- a/achieve_rails/config/initializers/redis.rb
+++ b/achieve_rails/config/initializers/redis.rb
@@ -1,0 +1,3 @@
+require 'redis'
+
+Rails.application.config.redis = Redis.new(url: ENV['REDIS_URL'] || 'redis://localhost:6379/0')

--- a/achieve_rails/config/routes.rb
+++ b/achieve_rails/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   resources :reports, only: %w[new create index]
   # resources :guests, only: ['create']
   resources :guests, only: [:create]
+  get 'ping', to: 'ping#index'
 end


### PR DESCRIPTION
## 概要

Upstash Redis が非アクティブ状態で削除されないよう、接続確認用のPing APIをRails側に実装しました。

## 変更内容
- `PingController` を作成し、Redisへのping処理を実装
- `config/routes.rb` にルーティングを追加
- `config/initializers/redis.rb` にRedisクライアントを初期化する設定を追加

## 背景

Upstash Redis の無料プランでは、一定期間アクセスがないと自動削除されるため、定期的にアクセスを発生させる必要があります。
これを回避するため、簡易的な接続確認用のエンドポイントを用意しました。

## 動作確認方法

Renderへデプロイ後、以下のコマンドを実行して `PONG` が返ることを確認：

```bash
curl https://backend-goals-achieve.onrender.com/ping
